### PR TITLE
Remove deadmeme command

### DIFF
--- a/src/main/java/adris/altoclef/AltoClefCommands.java
+++ b/src/main/java/adris/altoclef/AltoClefCommands.java
@@ -152,15 +152,6 @@ public class AltoClefCommands extends CommandList {
                 //mod.runUserTask(new PlaceStructureBlockTask(new BlockPos(472, 24, -324)));
                 break;
             }
-            case "deadmeme":
-                File file = new File("test.txt");
-                try {
-                    FileReader reader = new FileReader(file);
-                    mod.runUserTask(new BeeMovieTask("bruh", mod.getPlayer().getBlockPos(), reader));
-                } catch (FileNotFoundException e) {
-                    e.printStackTrace();
-                }
-                break;
             case "stacked":
                 // It should only need:
                 // 24 (armor) + 3*3 (pick) + 2 = 35 diamonds


### PR DESCRIPTION
deadmeme command referenced file `test.txt` not found in repository. Alternatively `test.txt` could be added to the repo.

In all seriousness though. How can I best contribute? I understand the focus right now is reliability over speed optimizations.