### PR TITLE
Allow buildsystem to rely entirely upon gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id 'fabric-loom' version '0.5-SNAPSHOT'
-    id 'maven-publish'
+    id "fabric-loom" version "0.5-SNAPSHOT"
+    id "maven-publish"
 }
 
 sourceCompatibility = JavaVersion.VERSION_1_8
@@ -11,22 +11,21 @@ version = project.mod_version
 group = project.maven_group
 
 repositories {
-    jcenter()
     mavenCentral()
     maven {
-        name = 'impactdevelopment-repo'
-        url = 'https://impactdevelopment.github.io/maven/'
+        name = "impactdevelopment-repo"
+        url = "https://impactdevelopment.github.io/maven/"
     }
 }
 
 dependencies {
     //to change the versions see the gradle.properties file
-    minecraft "com.mojang:minecraft:${project.minecraft_version}"
-    mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
-    modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+    minecraft("com.mojang:minecraft:${project.minecraft_version}")
+    mappings("net.fabricmc:yarn:${project.yarn_mappings}:v2")
+    modImplementation("net.fabricmc:fabric-loader:${project.loader_version}")
 
     // Fabric API. This is technically optional, but you probably want it anyway.
-    modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+    modImplementation("net.fabricmc.fabric-api:fabric-api:${project.fabric_version}")
 
     // PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
     // You may need to force-disable transitiveness on them.

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,15 @@ archivesBaseName = project.archives_base_name
 version = project.mod_version
 group = project.maven_group
 
+repositories {
+    jcenter()
+    mavenCentral()
+    maven {
+        name = 'impactdevelopment-repo'
+        url = 'https://impactdevelopment.github.io/maven/'
+    }
+}
+
 dependencies {
     //to change the versions see the gradle.properties file
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
@@ -21,7 +30,12 @@ dependencies {
 
     // PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
     // You may need to force-disable transitiveness on them.
-    compile files('libs/baritone-1.6.2-dev.jar')
+//    compile files('libs/baritone-1.6.2-dev.jar')
+    implementation("baritone:baritone:1.6.2-dev") {
+        version {
+            branch = "fabric/1.16.3"
+        }
+    }
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,11 @@
-# Done to increase the memory available to gradle.
-org.gradle.jvmargs=-Xmx1G
+# Gradle performance improvements
+org.gradle.jvmargs=-Xmx2048M -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC
+org.gradle.vfs.watch=true
+kapt.use.worker.api=true
+kapt.include.compile.classpath=false
+org.gradle.parallel=true
+org.gradle.caching=true
+org.gradle.warning.mode=all
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
 minecraft_version=1.16.4

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+# Gradle 5.3 breaks. 5.2.1 is the highest version we can go to.
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,10 +1,17 @@
 pluginManagement {
     repositories {
         jcenter()
+        mavenCentral()
         maven {
             name = 'Fabric'
             url = 'https://maven.fabricmc.net/'
         }
         gradlePluginPortal()
+    }
+}
+
+sourceControl {
+    gitRepository("https://gitlab.com/adrisj7/fabritone.git") {
+        producesModule("baritone:baritone")
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,17 +1,15 @@
 pluginManagement {
     repositories {
-        jcenter()
         mavenCentral()
         maven {
-            name = 'Fabric'
-            url = 'https://maven.fabricmc.net/'
+            name = "Fabric"
+            url = "https://maven.fabricmc.net/"
         }
-        gradlePluginPortal()
     }
 }
 
 sourceControl {
-    gitRepository("https://gitlab.com/adrisj7/fabritone.git") {
+    gitRepository(URI.create("https://gitlab.com/adrisj7/fabritone.git")) {
         producesModule("baritone:baritone")
     }
 }


### PR DESCRIPTION
Fixes #4

Note: I had to downgrade the gradle version. If you attempt to step up to 5.3, everything just falls apart. So, yeah.