### PR TITLE
Fix unused import that breaks compilation

### DIFF
--- a/src/main/java/adris/altoclef/tasksystem/chains/MLGBucketFallChain.java
+++ b/src/main/java/adris/altoclef/tasksystem/chains/MLGBucketFallChain.java
@@ -15,7 +15,6 @@ import adris.altoclef.util.baritone.InteractWithBlockPositionProcess;
 import adris.altoclef.util.csharpisbetter.Timer;
 import adris.altoclef.util.csharpisbetter.Util;
 import baritone.api.utils.Rotation;
-import javafx.scene.transform.Rotate;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.item.Items;
 import net.minecraft.util.math.BlockPos;


### PR DESCRIPTION
An accidental import was added for javafx in MLGBucketFallChain. It is not used, and it breaks compilation for people who don't have that library.